### PR TITLE
feat: migra interceptor de transações para Spring AOP com @LoggedTransaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,10 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/br/PraFrentexBankingApplication.java
+++ b/src/main/java/br/PraFrentexBankingApplication.java
@@ -2,7 +2,9 @@ package br;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
+@EnableAspectJAutoProxy
 @SpringBootApplication
 public class PraFrentexBankingApplication {
 

--- a/src/main/java/br/core/audit/LoggedTransaction.java
+++ b/src/main/java/br/core/audit/LoggedTransaction.java
@@ -1,0 +1,10 @@
+package br.core.audit;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LoggedTransaction {
+
+}

--- a/src/main/java/br/core/audit/TransactionInterceptor.java
+++ b/src/main/java/br/core/audit/TransactionInterceptor.java
@@ -1,0 +1,47 @@
+package br.core.audit;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+public class TransactionInterceptor {
+
+   private static final Logger logger = LoggerFactory.getLogger(TransactionInterceptor.class);
+
+   @Around("@annotation(br.service.audit.LoggedTransaction)")
+   public Object logTransaction(ProceedingJoinPoint joinPoint) throws Throwable {
+      LocalDateTime inicio = LocalDateTime.now();
+
+      MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+      String methodName = signature.getMethod().getName();
+      String className = joinPoint.getTarget().getClass().getSimpleName();
+
+      try {
+         logger.info("TRANSACTION_START | Method: {} | Class: {} | Time: {}",
+               methodName, className, inicio);
+         Object resultado = joinPoint.proceed();
+
+         LocalDateTime fim = LocalDateTime.now();
+         Duration duracao = Duration.between(inicio, fim);
+
+         logger.info("TRANSACTION_END | Method: {} | Class: {} | Duration: {}ms | Success: true",
+               methodName, className, duracao.toMillis());
+
+         return resultado;
+      } catch (Throwable e) {
+         logger.error("TRANSACTION_ERROR | Method: {} | Class: {} | Error: {}",
+               methodName, className, e.getMessage(), e);
+         throw e;
+      }
+   }
+
+}


### PR DESCRIPTION
Implementa classe TransactionInterceptor utilizando Spring AOP para interceptar métodos anotados com @LoggedTransaction.
A nova abordagem substitui a dependência de javax.interceptor por uma solução nativa do ecossistema Spring Boot,
mantendo o mesmo comportamento de logging de início, fim e falha de transações, com logs enriquecidos e melhor controle.

Motivação:
- Eliminar dependência de especificações JEE não compatíveis com Spring Boot puro
- Melhor integração com o contexto da aplicação (Beans, AOP)
- Facilitar evolução para métricas com Micrometer e Datadog futuramente

Impacto:
- Logging de transações centralizado com possibilidade de expansão futura
- Código mais alinhado com padrões modernos de observabilidade