### PR TITLE
feat: criar anotação customizada @ValidCNPJ com validador próprio

### DIFF
--- a/src/main/java/br/core/validation/cnpjvalidation/ValidCNPJ.java
+++ b/src/main/java/br/core/validation/cnpjvalidation/ValidCNPJ.java
@@ -1,0 +1,16 @@
+package br.core.validation.cnpjvalidation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ValidatorCPNJ.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCNPJ {
+
+    String message() default "CNPJ inválido";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
+++ b/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
@@ -1,0 +1,39 @@
+package br.core.validation.cnpjvalidation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class ValidatorCPNJ implements ConstraintValidator<ValidCNPJ, String> {
+
+    @Override
+    public void initialize(ValidCNPJ constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String cnpj, ConstraintValidatorContext context) {
+        if (cnpj == null) return false;
+
+        cnpj = cnpj.replaceAll("[^\\d]", "");
+
+        if (cnpj.length() != 14 || cnpj.matches("(\\d)\\1{13}")) return false;
+
+        int[] pesos1 = {5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+        int soma = 0;
+        for (int i = 0; i < 12; i++) {
+            soma += Character.getNumericValue(cnpj.charAt(i)) * pesos1[i];
+        }
+        int resto = soma % 11;
+        char digito1 = (resto < 2) ? '0' : (char) ((11 - resto) + '0');
+        if (digito1 != cnpj.charAt(12)) return false;
+
+        int[] pesos2 = {6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+        soma = 0;
+        for (int i = 0; i < 13; i++) {
+            soma += Character.getNumericValue(cnpj.charAt(i)) * pesos2[i];
+        }
+        resto = soma % 11;
+        char digito2 = (resto < 2) ? '0' : (char) ((11 - resto) + '0');
+
+        return digito2 == cnpj.charAt(13);
+    }
+}


### PR DESCRIPTION
feat: criar anotação customizada @ValidCNPJ com validador próprio

- Implementada anotação customizada @ValidCNPJ para validação de CNPJs em DTOs e entidades.
- Criada a classe ValidCNPJValidator que implementa ConstraintValidator<ValidCNPJ, String>, responsável por validar o formato e dígitos verificadores do CNPJ.
- Utilizado algoritmo oficial de validação, incluindo remoção de formatação e verificação contra números repetidos.
- Removida dependência do validador interno do Hibernate Validator (org.hibernate.validator.internal.constraintvalidators.hv.br.CNPJValidator), adotando abordagem própria para maior controle e independência.
- Método initialize() implementado conforme exigência da interface ConstraintValidator.
- Adicionadas anotações @ Target, @ Retention e @ Constraint corretamente para permitir uso em campos e parâmetros.
- Código preparado para integração com Bean Validation (JSR 380) via spring-boot-starter-validation.

Motivação:
Essa migração tem como objetivo eliminar dependência interna do Hibernate Validator, evitando acoplamento com APIs internas e aumentando a transparência e manutenibilidade do código. A validação agora é de responsabilidade total do projeto, com possibilidade de ajustes futuros em mensagens, formato e lógica.
