### PR TITLE
feat(validation): Implementa validadores customizados para CPF e CNPJ

### DIFF
--- a/src/main/java/br/core/validation/cnpjvalidation/ValidCNPJ.java
+++ b/src/main/java/br/core/validation/cnpjvalidation/ValidCNPJ.java
@@ -1,7 +1,7 @@
 package br.core.validation.cnpjvalidation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.*;
 
 @Documented

--- a/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
+++ b/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
@@ -1,18 +1,16 @@
 package br.core.validation.cnpjvalidation;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 
 public class ValidatorCPNJ implements ConstraintValidator<ValidCNPJ, String> {
 
     @Override
-    public void initialize(ValidCNPJ constraintAnnotation) {
-    }
-
-    @Override
     public boolean isValid(String cnpj, ConstraintValidatorContext context) {
-        if (cnpj == null) return false;
-
+        if (cnpj == null) {
+            return true;
+        }
+        
         cnpj = cnpj.replaceAll("[^\\d]", "");
 
         if (cnpj.length() != 14 || cnpj.matches("(\\d)\\1{13}")) return false;

--- a/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
+++ b/src/main/java/br/core/validation/cnpjvalidation/ValidatorCPNJ.java
@@ -5,33 +5,45 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class ValidatorCPNJ implements ConstraintValidator<ValidCNPJ, String> {
 
+    private static final int[] WEIGHTS_DIGIT_1 = {5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+    private static final int[] WEIGHTS_DIGIT_2 = {6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+
     @Override
     public boolean isValid(String cnpj, ConstraintValidatorContext context) {
         if (cnpj == null) {
-            return true;
+            return true; 
         }
         
-        cnpj = cnpj.replaceAll("[^\\d]", "");
+        String cleanedCnpj = cnpj.replaceAll("\\D", "");
 
-        if (cnpj.length() != 14 || cnpj.matches("(\\d)\\1{13}")) return false;
-
-        int[] pesos1 = {5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
-        int soma = 0;
-        for (int i = 0; i < 12; i++) {
-            soma += Character.getNumericValue(cnpj.charAt(i)) * pesos1[i];
+        if (cleanedCnpj.length() != 14 || hasAllSameDigits(cleanedCnpj)) {
+            return false;
         }
-        int resto = soma % 11;
-        char digito1 = (resto < 2) ? '0' : (char) ((11 - resto) + '0');
-        if (digito1 != cnpj.charAt(12)) return false;
 
-        int[] pesos2 = {6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
-        soma = 0;
-        for (int i = 0; i < 13; i++) {
-            soma += Character.getNumericValue(cnpj.charAt(i)) * pesos2[i];
+        try {
+            String firstDigit = String.valueOf(calculateDigit(cleanedCnpj.substring(0, 12), WEIGHTS_DIGIT_1));
+            if (!cleanedCnpj.substring(12, 13).equals(firstDigit)) {
+                return false;
+            }
+
+            String secondDigit = String.valueOf(calculateDigit(cleanedCnpj.substring(0, 13), WEIGHTS_DIGIT_2));
+            return cleanedCnpj.substring(13, 14).equals(secondDigit);
+
+        } catch (NumberFormatException e) {
+            return false;
         }
-        resto = soma % 11;
-        char digito2 = (resto < 2) ? '0' : (char) ((11 - resto) + '0');
+    }
 
-        return digito2 == cnpj.charAt(13);
+    private boolean hasAllSameDigits(String cnpj) {
+        return cnpj.chars().distinct().count() == 1;
+    }
+
+    private int calculateDigit(String base, int[] weights) {
+        int sum = 0;
+        for (int i = 0; i < base.length(); i++) {
+            sum += Character.getNumericValue(base.charAt(i)) * weights[i];
+        }
+        int remainder = sum % 11;
+        return (remainder < 2) ? 0 : 11 - remainder;
     }
 }


### PR DESCRIPTION
Este commit introduz um conjunto de validadores de constraints customizados para CPF e CNPJ, garantindo a integridade e o formato correto desses documentos no sistema.

As implementações seguem os algoritmos oficiais de cálculo dos dígitos verificadores e foram projetadas para se integrar perfeitamente ao ecossistema de validação do Spring Boot.

Principais Alterações:
- **`@ValidCPF` e `ValidatorCPF`**: Adiciona uma anotação e sua lógica de validação para CPFs. O validador trata a limpeza de caracteres não numéricos, verifica o tamanho e invalida sequências de dígitos repetidos (ex: 111.111.111-11).
- **`@ValidCNPJ` e `ValidatorCPNJ`**: Adiciona uma anotação e sua lógica de validação para CNPJs, com tratamento similar para limpeza de string e invalidação de sequências repetidas.
- **Migração para Jakarta EE**: Todas as importações de `javax.validation` foram atualizadas para `jakarta.validation`, garantindo total compatibilidade com o Spring Boot 3 e resolvendo erros de compilação.
- **Refatoração**: A lógica dos validadores foi refatorada para maior clareza, com a extração de responsabilidades para métodos privados e nomes explícitos.
