### PR TITLE
docs: Aprimora script de execução e documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,26 +156,89 @@ Este projeto é uma aplicação baseada em **Spring Boot**, desenvolvida com o o
 
 ---
 
-## Como rodar
+## Como Executar o Projeto
 
-1. **Build:**  
-   ```sh
-   ./mvnw clean package
-   ```
+Este projeto pode ser executado de duas maneiras principais: a forma padrão, ideal para desenvolvimento rápido, ou com a integração de monitoramento da Datadog.
 
-2. **Executar:**  
-   ```sh
-   ./mvnw spring-boot:run
-   ```
+### 1. Execução Padrão (Sem Datadog)
 
-3. **Testes:**  
-   ```sh
-   ./mvnw test
-   ```
+Use os comandos do Maven Wrapper (`mvnw`) para compilar e rodar a aplicação.
+
+**Opção A: Comando Direto (Recomendado para desenvolvimento)**
+
+Este comando compila e inicia a aplicação em um único passo.
+```sh
+./mvnw spring-boot:run
+```
+
+**Opção B: Compilando o Pacote `.jar`**
+
+Este método é mais próximo de um ambiente de produção, onde você primeiro gera o artefato e depois o executa.
+
+1.  **Compile e empacote o projeto (pulando os testes):**
+    ```sh
+    ./mvnw clean package -DskipTests
+    ```
+2.  **Execute o arquivo JAR gerado:**
+    ```sh
+    java -jar target/backing-0.0.1-SNAPSHOT.jar
+    ```
+
+### 2. Execução com Monitoramento Datadog
+
+Para uma execução com observabilidade completa (traces, métricas e logs), utilize o script `start-with-datadog.sh`.
+
+#### Pré-requisitos
+
+*   **Java 17+** instalado.
+*   **Conta na Datadog** e uma **API Key** válida.
+
+#### Passo a Passo
+
+**1. Configure sua Chave da API do Datadog**
+
+O script utiliza uma variável de ambiente para carregar sua API Key de forma segura. Antes de executar, exporte a variável no seu terminal:
+
+*   **No Linux ou macOS:**
+    ```sh
+    export DATADOG_API_KEY='sua_chave_de_api_aqui'
+    ```
+*   **No Windows (PowerShell):**
+    ```powershell
+    $env:DATADOG_API_KEY="sua_chave_de_api_aqui"
+    ```
+> ⚠️ **Importante:** Substitua `sua_chave_de_api_aqui` pela sua chave real. Não armazene a chave diretamente no script.
+
+**2. Dê Permissão de Execução ao Script (Apenas Linux/macOS)**
+
+Pode ser necessário tornar o script executável:
+```sh
+chmod +x start-with-datadog.sh
+```
+
+**3. Execute o Script**
+
+Na raiz do projeto, execute:
+```sh
+./start-with-datadog.sh
+```
+
+#### O que o Script Faz?
+
+1.  **Verifica a API Key**: Confere se a variável de ambiente `DATADOG_API_KEY` foi definida.
+2.  **Compila o Projeto**: Executa `./mvnw clean install -DskipTests` para gerar o arquivo `.jar` na pasta `target`.
+3.  **Baixa o Agente Datadog**: Verifica se o `dd-java-agent.jar` existe e, caso contrário, baixa a versão mais recente.
+4.  **Inicia a Aplicação com o Agente**: Executa o `.jar` anexando o agente da Datadog (`-javaagent`), que instrumenta a aplicação para coletar e enviar dados de telemetria.
+
+## Como Rodar os Testes
+
+Para executar a suíte de testes unitários e de integração, utilize o comando:
+```sh
+./mvnw test
+```
 
 ## Observações
 
-- O projeto utiliza Java 17.
 - Para funcionalidades de IA, Redis e Kafka, é recomendado rodar os serviços via Docker Compose.
 - O monitoramento pode ser integrado ao Dynatrace.
 - A documentação da API pode ser gerada automaticamente via Spring REST Docs.

--- a/start-with-datadog.sh
+++ b/start-with-datadog.sh
@@ -6,15 +6,22 @@
 SERVICE_NAME="springboot-app"
 ENVIRONMENT="dev"
 APP_VERSION="1.0.0"
-JAR_PATH="target/$(ls target | grep '.jar$' | head -n1)"
+JAR_NAME="backing-0.0.1-SNAPSHOT.jar"
+JAR_PATH="target/$JAR_NAME"
 DD_AGENT_JAR="dd-java-agent.jar"
-DD_API_KEY="{DATADOG_API_KEY}"
+
+# Leia a chave da API do Datadog de uma variável de ambiente para segurança.
+# Antes de executar, defina a variável: export DATADOG_API_KEY='sua_chave_aqui'
+if [ -z "$DATADOG_API_KEY" ]; then
+  echo "❌ Erro: A variável de ambiente DATADOG_API_KEY não está definida."
+  exit 1
+fi
 
 # ========================
 # 1. Limpa e instala o projeto
 # ========================
-echo "🔄 Limpando e instalando o projeto Maven..."
-mvn clean install -DskipTests
+echo "🔄 Limpando e instalando o projeto com o Maven Wrapper..."
+./mvnw clean install -DskipTests
 
 if [ $? -ne 0 ]; then
   echo "❌ Erro ao compilar o projeto."
@@ -42,7 +49,7 @@ java \
   -Ddd.version="$APP_VERSION" \
   -Ddd.logs.injection=true \
   -Ddd.trace.enabled=true \
-  -Ddd.api.key="$DD_API_KEY" \
+  -Ddd.api.key="$DATADOG_API_KEY" \
   -jar "$JAR_PATH"
 
 # ========================


### PR DESCRIPTION
Este commit melhora significativamente a experiência do desenvolvedor ao reestruturar a documentação do projeto e aprimorar o script de inicialização com Datadog.

As principais motivações para esta mudança foram:
- Fornecer instruções claras e passo a passo para novos desenvolvedores sobre como compilar e executar a aplicação.
- Aumentar a segurança da integração com o Datadog, removendo segredos (API key) do código do script.
- Tornar o processo de build e execução mais robusto e consistente entre diferentes ambientes.

Principais alterações:

No `README.md`:
- A seção `## Como rodar` foi reestruturada para `## Como Executar o Projeto`, tornando-a mais completa e organizada.
- Foram criados guias distintos para "Execução Padrão" e "Execução com Monitoramento Datadog".
- Adicionadas explicações detalhadas para cada comando e etapa do script, clarificando o que acontece em cada fase.
- As instruções de teste foram movidas para uma seção dedicada (`## Como Rodar os Testes`) para melhor organização.

No `start-with-datadog.sh`:
- **Segurança:** A API key do Datadog não é mais fixa no código. Agora, ela é lida da variável de ambiente `DATADOG_API_KEY`, seguindo as melhores práticas de segurança. Uma verificação foi adicionada para garantir que a variável esteja definida.
- **Robustez:** O script agora usa um caminho estático para o arquivo JAR gerado (`target/backing-0.0.1-SNAPSHOT.jar`), em vez de depender de um comando frágil como `ls | grep`.
- **Consistência:** O comando `mvn` foi substituído por `./mvnw` para utilizar o Maven Wrapper, garantindo que todos os desenvolvedores e pipelines de CI/CD usem a mesma versão do Maven.

Essas mudanças tornam o projeto mais acessível, seguro e fácil de gerenciar.
