### PR TITLE
refactor(security): Adota Spring Security para hashing de senhas

### DIFF
--- a/src/main/java/br/domain/model/usuarios/service/UserService.java
+++ b/src/main/java/br/domain/model/usuarios/service/UserService.java
@@ -1,0 +1,30 @@
+package br.domain.model.usuarios.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+         definição em SecurityConfig.
+     */
+    public UserService(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public String codificarSenha(String senhaPura) {
+        // Usa o encoder para criar um hash seguro da senha
+        // O BCrypt já gera e embute um "salt" aleatório no hash
+        return passwordEncoder.encode(senhaPura);
+    }
+
+    public boolean verificarSenha(String senhaPura, String senhaCodificada) {
+        // Usa o encoder para comparar a senha pura com a versão codificada
+        return passwordEncoder.matches(senhaPura, senhaCodificada);
+    }
+}
+
+


### PR DESCRIPTION
Remove a implementação customizada e insegura de hashing de senhas que utilizava Base64 com um 'salt' estático. Este método era vulnerável a ataques de reversão e rainbow table.

Esta mudança refatora o sistema para utilizar a abstração `PasswordEncoder` do Spring Security, com a implementação padrão `BCryptPasswordEncoder`.

Principais alterações:
- A classe `Password.java` foi removida.
- O `BCryptPasswordEncoder` foi configurado como um Bean em `SecurityConfig`.
- O `UserService` agora injeta e utiliza o `PasswordEncoder` para codificar e verificar senhas de forma segura.
- A segurança do Spring foi ativada no `application.properties`, e uma política padrão de 'negar tudo' foi configurada em `SecurityConfig`, exigindo autenticação para todos os endpoints.

Isso alinha o projeto com as melhores práticas de segurança da indústria, aumentando a robustez contra ataques de força bruta e garantindo que as senhas dos usuários sejam armazenadas corretamente.
